### PR TITLE
Nack using the message instead of the message ID

### DIFF
--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -535,7 +535,7 @@ func (c *consumer) Nack(msg Message) {
 		}
 
 		if mid.consumer != nil {
-			mid.consumer.NackID(msg.ID())
+			mid.consumer.NackMsg(msg)
 			return
 		}
 		c.consumers[mid.partitionIdx].NackMsg(msg)


### PR DESCRIPTION
This will allow nack back-off policy to be used instead of being ignored.